### PR TITLE
Add paper on consistency models in noSql databases

### DIFF
--- a/papers/README.md
+++ b/papers/README.md
@@ -21,3 +21,4 @@
 - [The Part-Time Parliament](https://lamport.azurewebsites.net/pubs/lamport-paxos.pdf)
 - [Time, clocks and the Ordering of events in a Distributed System](https://lamport.azurewebsites.net/pubs/time-clocks.pdf)
 - [Zookeeper](https://www.usenix.org/legacy/event/usenix10/tech/full_papers/Hunt.pdf)
+- [Consistency Models of NoSQL Databases](https://res.mdpi.com/d_attachment/futureinternet/futureinternet-11-00043/article_deploy/futureinternet-11-00043.pdf)


### PR DESCRIPTION
This commit adds the Consistency Models of NoSQL Databases paper link 
by Miguel Diogo, Bruno Cabral and Jorge Bernardino.

The paper provides general overview on different consistency model around cap theorem and how a handful of noSql databases fits in those models 